### PR TITLE
Adding support for arm64 architecture.

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -33,5 +33,6 @@ jobs:
      - name: Build and push to DockerHub
        uses: docker/build-push-action@v2
        with:
+         platforms: linux/amd64,linux/arm64
          tags: "${{env.CALVER_TARGET}}, ${{env.LATEST_TARGET}}"
          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10 AS base
+FROM ubuntu:bionic-20220315 AS base
 
 RUN apt-get update && apt-get install --yes --no-install-recommends \
     # support singularity build/pull workflows
@@ -22,10 +22,12 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     cryptsetup \
   && rm -rf /var/lib/apt/lists/*
 
+ARG TARGETARCH
+
 RUN export VERSION=1.16.4 \
- && wget --quiet https://golang.org/dl/go${VERSION}.linux-amd64.tar.gz \
- && tar -C /usr/local -xzf go${VERSION}.linux-amd64.tar.gz \
- && rm /go${VERSION}.linux-amd64.tar.gz
+ && wget --quiet https://golang.org/dl/go${VERSION}.linux-${TARGETARCH}.tar.gz \
+ && tar -C /usr/local -xzf go${VERSION}.linux-${TARGETARCH}.tar.gz \
+ && rm /go${VERSION}.linux-${TARGETARCH}.tar.gz
 
 ENV PATH=$PATH:/usr/local/go/bin
 


### PR DESCRIPTION
With the new Apple M1 chips (arm64 architecture) the conversion of Docker images to Singularity images with this container  needs twice as much time. I tried to add support for building this Docker image with the amd64 and arm64 architecture and upload both of them to Docker Hub so no one has to care and can pull the image with the matching architecture.